### PR TITLE
scoverage-intro

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")


### PR DESCRIPTION
Add scoverage plugin to check test coverage. 
To get the report you have to run coverageReport in the sbt shell after the reload (first time) and then you can find the html version in target/scala-3.3.0/scoverage-report/index.html