### PR TITLE
chore: replace scoverage tool with jacoco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Clear Target Folder
-        run: rm -d -r ./target
+        run: ls -a rm -d -r target
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Clear Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/target
+
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'none'
       - name: Run tests
         run: sbt test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Clear Target Folder
-        run: rm -D -r ./target
+        run: rm -d -r ./target
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Clear Target Folder
-        run: ls -a; rm -d -r target
-
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Clear Target Folder
-        run: ls -a rm -d -r target
+        run: ls -a; rm -d -r target
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Clear Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/target
+      - name: Clear Target Folder
+        run: rm ~/target
 
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'sbt'
       - name: Run tests
         run: sbt test
 
@@ -44,6 +43,5 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'sbt'
       - name: Check scalafmt formatting
         run: sbt scalafmtCheckAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Clear Target Folder
-        run: rm ~/target
-
       - uses: actions/checkout@v3
+
+      - name: Clear Target Folder
+        run: rm -D -r ./target
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'none'
+          cache: 'sbt'
       - name: Run tests
         run: sbt test
 
@@ -47,5 +48,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'sbt'
       - name: Check scalafmt formatting
         run: sbt scalafmtCheckAll

--- a/build.sbt
+++ b/build.sbt
@@ -16,3 +16,13 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(scalaTest, archUnit, slf4jSimpleLog, scalaSwing, scalaCompiler, cucumber),
     assembly / assemblyJarName := "satify.jar",
   )
+
+jacocoReportSettings := JacocoReportSettings()
+  .withTitle("Jacoco Satify Coverage Report")
+  .withThresholds(
+    JacocoThresholds(
+      branch = 40,
+      line = 70)
+  )
+  .withFormats(JacocoReportFormats.ScalaHTML)
+jacocoExcludes := Seq("*view*", "*update.Message*", "*Main*")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")

--- a/src/test/scala/satify/TestArchitecture.scala
+++ b/src/test/scala/satify/TestArchitecture.scala
@@ -1,7 +1,7 @@
 package satify
 
 import com.tngtech.archunit.core.domain.JavaClasses
-import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.{ClassFileImporter, ImportOption}
 import com.tngtech.archunit.lang.ArchRule
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.{classes, noClasses}
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
@@ -22,7 +22,7 @@ class TestArchitecture extends AnyFlatSpec with Matchers:
   val UpdatePackage: String = RootPackage + ".update"
   val ViewPackage: String = RootPackage + ".view"
 
-  val allClasses: JavaClasses = ClassFileImporter().importPackages(RootPackage)
+  val allClasses: JavaClasses = ClassFileImporter().withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS).importPackages(RootPackage)
 
   "Architecture" should "not have cyclic dependencies" in {
     val noCycles: ArchRule = slices()

--- a/src/test/scala/satify/TestArchitecture.scala
+++ b/src/test/scala/satify/TestArchitecture.scala
@@ -1,7 +1,7 @@
 package satify
 
 import com.tngtech.archunit.core.domain.JavaClasses
-import com.tngtech.archunit.core.importer.{ClassFileImporter, ImportOption}
+import com.tngtech.archunit.core.importer.{ClassFileImporter, ImportOption, Location}
 import com.tngtech.archunit.lang.ArchRule
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.{classes, noClasses}
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
@@ -22,7 +22,10 @@ class TestArchitecture extends AnyFlatSpec with Matchers:
   val UpdatePackage: String = RootPackage + ".update"
   val ViewPackage: String = RootPackage + ".view"
 
-  val allClasses: JavaClasses = ClassFileImporter().withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS).importPackages(RootPackage)
+  def excludeInstrumented: ImportOption = new ImportOption {
+    override def includes(location: Location): Boolean = !location.contains("instrumented-classes")
+  }
+  val allClasses: JavaClasses = ClassFileImporter().withImportOption(excludeInstrumented).importPackages(RootPackage)
 
   "Architecture" should "not have cyclic dependencies" in {
     val noCycles: ArchRule = slices()

--- a/src/test/scala/satify/TestArchitecture.scala
+++ b/src/test/scala/satify/TestArchitecture.scala
@@ -22,9 +22,7 @@ class TestArchitecture extends AnyFlatSpec with Matchers:
   val UpdatePackage: String = RootPackage + ".update"
   val ViewPackage: String = RootPackage + ".view"
 
-  def excludeInstrumented: ImportOption = new ImportOption {
-    override def includes(location: Location): Boolean = !location.contains("instrumented-classes")
-  }
+  val excludeInstrumented: ImportOption = (location: Location) => !location.contains("instrumented-classes")
   val allClasses: JavaClasses = ClassFileImporter().withImportOption(excludeInstrumented).importPackages(RootPackage)
 
   "Architecture" should "not have cyclic dependencies" in {
@@ -32,7 +30,6 @@ class TestArchitecture extends AnyFlatSpec with Matchers:
       .matching(RootPackage + ".(*)..")
       .should()
       .beFreeOfCycles()
-
     noCycles.check(allClasses)
   }
 


### PR DESCRIPTION
Replace Scoverage plugin with Jacoco because with Scoverage was not possible to exclude packages (like the view one) for Scala 3 code (Note in section Exclude classes and packages and files at https://github.com/scoverage/sbt-scoverage).
For now i just set 70% in line check. 

To see coverage report with Jacoco simply run "jacoco" in the sbt shell and then you can see a first result in the shell or the entire html report in target/scala-3.3.0/jacoco/report/html/index.html