### PR TITLE
Feature/tailrec-parser-cnf-refactor

### DIFF
--- a/src/main/scala/satify/model/CNF.scala
+++ b/src/main/scala/satify/model/CNF.scala
@@ -3,8 +3,6 @@ package satify.model
 /** An enum representing a Conjunction Normal Form (CNF) expression. */
 import satify.model.CNF.*
 
-case class Variable(name: String, value: Option[Boolean] = None)
-
 enum Bool:
   case True
   case False
@@ -12,7 +10,7 @@ enum Bool:
 type Literal = Symbol | Not
 
 enum CNF:
-  case Symbol(value: Variable | Bool)
+  case Symbol(value: String | Bool)
   case And(left: Or | Literal, right: And | Or | Literal)
   case Or(left: Or | Literal, right: Or | Literal)
   case Not(branch: Symbol)
@@ -21,10 +19,7 @@ object CNF:
   extension (cnf: CNF)
     def printAsDSL(flat: Boolean = false): String =
       cnf match
-        case Symbol(value) =>
-          value match
-            case Variable(name, v) => name
-            case v => v.toString
+        case Symbol(name) => name.toString
         case And(left, right) =>
           if flat then s"${left.printAsDSL(flat)} and ${right.printAsDSL(flat)}"
           else s"${left.printAsDSL(flat)} and\n${right.printAsDSL(flat)}"

--- a/src/main/scala/satify/model/dpll/PartialModel.scala
+++ b/src/main/scala/satify/model/dpll/PartialModel.scala
@@ -1,6 +1,6 @@
 package satify.model.dpll
 
-import satify.model.Variable
+case class Variable(name: String, value: Option[Boolean] = None)
 
 type PartialModel = Seq[Variable]
 

--- a/src/main/scala/satify/model/problems/NQueens.scala
+++ b/src/main/scala/satify/model/problems/NQueens.scala
@@ -1,6 +1,6 @@
 package satify.model.problems
 
-import satify.model.Variable
+import satify.model.dpll.Variable
 import satify.model.dpll.OrderedSeq.{given_Ordering_Variable, seq}
 import satify.model.dpll.PartialModel
 import satify.model.expression.Encodings.{atLeastOne, atMostOne}

--- a/src/main/scala/satify/model/problems/NQueens.scala
+++ b/src/main/scala/satify/model/problems/NQueens.scala
@@ -53,7 +53,7 @@ case class NQueens(n: Int) extends Problem:
         )
       )
 
-  val exp: Expression = buildAnd(rowColConstr ++ diagConstr: _*)
+  val exp: Expression = (rowColConstr ++ diagConstr).reduceLeft(And(_, _))
 
 object NQueens:
   def printNQueensFromDimacs(n: Int, pm: PartialModel): Unit =
@@ -78,5 +78,3 @@ object NQueens:
         )
       )
       printNqueens(n, pm.drop(n))
-
-def buildAnd(exp: Expression*): Expression = exp.reduceLeft(And(_, _))

--- a/src/main/scala/satify/update/Update.scala
+++ b/src/main/scala/satify/update/Update.scala
@@ -110,7 +110,7 @@ object Update:
         val s: Source = Source.fromFile(file)
         val lines = s.getLines.toSeq
         s.close()
-        val cnf: CNF = parse(lines).getOrElse(Symbol(Variable("NO CNF")))
+        val cnf: CNF = parse(lines).getOrElse(Symbol("NO CNF"))
         val input = cnf.printAsDSL()
         State(input, cnf)
       ,

--- a/src/main/scala/satify/update/converters/TseitinTransformation.scala
+++ b/src/main/scala/satify/update/converters/TseitinTransformation.scala
@@ -1,7 +1,7 @@
 package satify.update.converters
 
 import satify.model.expression.Expression
-import satify.model.{CNF, Variable}
+import satify.model.CNF
 import scala.annotation.tailrec
 
 /** Object containing the Tseitin transformation algorithm. */
@@ -30,7 +30,7 @@ private[converters] object TseitinTransformation:
     if subexpressions.size == 1 then subexpressions.head
     else
       var concatenated = subexpressions
-      concatenated = concatenated.prepended(CNFSymbol(Variable("TSTN0")))
+      concatenated = concatenated.prepended(CNFSymbol("TSTN0"))
       concatenated.reduceRight((s1, s2) =>
         CNFAnd(s1.asInstanceOf[CNFOr | Literal], s2.asInstanceOf[CNFAnd | CNFOr | Literal])
       )
@@ -78,15 +78,15 @@ private[converters] object TseitinTransformation:
     */
   def transform(exp: (Expression.Symbol, Expression)): List[CNF] =
     def expr(exp: Expression): Literal = exp match
-      case Symbol(v) => CNFSymbol(Variable(v, None))
-      case Not(Symbol(v)) => CNFNot(CNFSymbol(Variable(v, None)))
+      case Symbol(v) => CNFSymbol(v)
+      case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
       case _ => throw new IllegalArgumentException("Expression is not a literal")
     def symbol(exp: Expression): CNFSymbol = exp match
-      case Symbol(v) => CNFSymbol(Variable(v, None))
+      case Symbol(v) => CNFSymbol(v)
       case _ => throw new IllegalArgumentException("Expression is not a literal")
     def not(exp: Expression): Literal = exp match
-      case Not(Symbol(v)) => CNFSymbol(Variable(v, None))
-      case Symbol(v) => CNFNot(CNFSymbol(Variable(v, None)))
+      case Not(Symbol(v)) => CNFSymbol(v)
+      case Symbol(v) => CNFNot(CNFSymbol(v))
       case _ =>
         throw new IllegalArgumentException("Expression is not a literal")
 
@@ -133,18 +133,18 @@ private[converters] object TseitinTransformation:
   def convertToCNF(expression: Expression): CNF =
     def convL(exp: Expression): CNFOr | Literal = exp match
       case Or(l, r) => CNFOr(convL(l), convL(r))
-      case Symbol(v) => CNFSymbol(Variable(v))
-      case Not(Symbol(v)) => CNFNot(CNFSymbol(Variable(v)))
+      case Symbol(v) => CNFSymbol(v)
+      case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
       case _ => throw new Exception("Expression is not convertible to CNF form")
     def convR(exp: Expression): CNFAnd | CNFOr | Literal = exp match
       case And(l, r) => CNFAnd(convL(l), convR(r))
       case Or(l, r) => CNFOr(convL(l), convL(r))
-      case Symbol(v) => CNFSymbol(Variable(v))
-      case Not(Symbol(v)) => CNFNot(CNFSymbol(Variable(v)))
+      case Symbol(v) => CNFSymbol(v)
+      case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
       case _ => throw new Exception("Expression is not convertible to CNF form")
     expression match
-      case Symbol(v) => CNFSymbol(Variable(v))
-      case Not(Symbol(v)) => CNFNot(CNFSymbol(Variable(v)))
+      case Symbol(v) => CNFSymbol(v)
+      case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
       case And(l, r) => CNFAnd(convL(l), convR(r))
       case Or(l, r) => CNFOr(convL(l), convL(r))
       case _ => throw new Exception("Expression is not convertible to CNF form")

--- a/src/main/scala/satify/update/parser/Dimacs.scala
+++ b/src/main/scala/satify/update/parser/Dimacs.scala
@@ -2,7 +2,7 @@ package satify.update.parser
 
 import satify.model.CNF.*
 import satify.model.expression.Expression
-import satify.model.{CNF, Literal, Variable}
+import satify.model.{CNF, Literal}
 
 import scala.io.Source
 
@@ -65,8 +65,8 @@ object DimacsCNF extends Dimacs[CNF]:
         .map(s =>
           val flatIdx = math.abs(s.toInt)
           val literal: Literal = s.toInt match
-            case _ if s.toInt > 0 => Symbol(Variable(f"x_$flatIdx"))
-            case _ => Not(Symbol(Variable(f"x_$flatIdx")))
+            case _ if s.toInt > 0 => Symbol(f"x_$flatIdx")
+            case _ => Not(Symbol(f"x_$flatIdx"))
           literal
         )
         .toSeq
@@ -84,8 +84,8 @@ object DimacsCNF extends Dimacs[CNF]:
       case None => buildOrCNF(literals.tail, Some(literals.head))
       case Some(prev) =>
         literals match
-          case head +: Seq() => Or(prev, head)
-          case head +: tail => buildOrCNF(tail, Some(Or(prev, head)))
+          case head +: Seq() => Or(head, prev)
+          case head +: tail => buildOrCNF(tail, Some(Or(head, prev)))
 
   private def buildAndCNF(literals: Seq[Or | Literal], p: Option[And | Or | Literal] = None): And | Or | Literal =
     p match

--- a/src/main/scala/satify/update/solver/dpll/Dpll.scala
+++ b/src/main/scala/satify/update/solver/dpll/Dpll.scala
@@ -2,8 +2,8 @@ package satify.update.solver.dpll
 
 import satify.model.Bool.{False, True}
 import satify.model.CNF.{And, Not, Or, Symbol}
-import satify.model.{CNF, Variable}
-import satify.model.dpll.{Constraint, Decision, DecisionTree, PartialModel}
+import satify.model.CNF
+import satify.model.dpll.{Constraint, Decision, DecisionTree, PartialModel, Variable}
 import satify.model.dpll.DecisionTree.{Branch, Leaf}
 import satify.update.solver.dpll.cnf.CNFSimplification.simplifyCnf
 import satify.update.solver.dpll.cnf.CNFSat.{isSat, isUnsat}

--- a/src/main/scala/satify/update/solver/dpll/Optimizations.scala
+++ b/src/main/scala/satify/update/solver/dpll/Optimizations.scala
@@ -1,8 +1,8 @@
 package satify.update.solver.dpll
 
-import satify.model.{CNF, Variable}
+import satify.model.CNF
 import satify.model.CNF.*
-import satify.model.dpll.{Constraint, Decision}
+import satify.model.dpll.{Constraint, Decision, Variable}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.{AbstractSeq, LinearSeq}
@@ -26,8 +26,8 @@ object Optimizations:
     val f: (CNF, Option[Constraint]) => Option[Constraint] =
       (cnf, d) =>
         cnf match
-          case Symbol(Variable(name, _)) => Some(Constraint(name, true))
-          case Not(Symbol(Variable(name, _))) => Some(Constraint(name, false))
+          case Symbol(name: String) => Some(Constraint(name, true))
+          case Not(Symbol(name: String)) => Some(Constraint(name, false))
           case _ => d
 
     f(
@@ -58,8 +58,8 @@ object Optimizations:
           case Discordant => Discordant
 
       cnf match
-        case Symbol(Variable(n, _)) if name == n => Concordant(Constraint(n, true))
-        case Not(Symbol(Variable(n, _))) if name == n => Concordant(Constraint(n, false))
+        case Symbol(n: String) if name == n => Concordant(Constraint(n, true))
+        case Not(Symbol(n: String)) if name == n => Concordant(Constraint(n, false))
         case And(left, right) => f(name, left, right)
         case Or(left, right) => f(name, left, right)
         case _ => Missing

--- a/src/main/scala/satify/update/solver/dpll/cnf/CNFSat.scala
+++ b/src/main/scala/satify/update/solver/dpll/cnf/CNFSat.scala
@@ -2,7 +2,8 @@ package satify.update.solver.dpll.cnf
 
 import satify.model.Bool.{False, True}
 import satify.model.CNF.{And, Not, Or, Symbol}
-import satify.model.{Bool, CNF, Variable}
+import satify.model.{Bool, CNF}
+import satify.model.dpll.Variable
 
 object CNFSat:
 
@@ -19,7 +20,7 @@ object CNFSat:
         case _ => d
 
     cnf match
-      case Not(Symbol(_: Variable)) | Symbol(_: Variable) | Not(Symbol(False)) | Symbol(True) | Or(_, _) => false
+      case Not(Symbol(_: String)) | Symbol(_: String) | Not(Symbol(False)) | Symbol(True) | Or(_, _) => false
       case Not(Symbol(True)) | Symbol(False) => true
       case And(left, right) =>
         f(

--- a/src/main/scala/satify/update/solver/dpll/cnf/CNFSimplification.scala
+++ b/src/main/scala/satify/update/solver/dpll/cnf/CNFSimplification.scala
@@ -2,8 +2,8 @@ package satify.update.solver.dpll.cnf
 
 import satify.model.Bool.{False, True}
 import satify.model.CNF.*
-import satify.model.dpll.Constraint
-import satify.model.{CNF, Variable}
+import satify.model.dpll.{Constraint, Variable}
+import satify.model.CNF
 
 object CNFSimplification:
 
@@ -33,9 +33,9 @@ object CNFSimplification:
       */
     def f[V <: CNF](e: V, d: T): T =
       (e match
-        case Symbol(Variable(name, _)) if name == constr.name && constr.value => Symbol(True)
+        case Symbol(name: String) if name == constr.name && constr.value => Symbol(True)
         case s @ Symbol(True) => s
-        case Not(Symbol(Variable(name, _))) if name == constr.name && !constr.value => Symbol(True)
+        case Not(Symbol(name: String)) if name == constr.name && !constr.value => Symbol(True)
         case Not(Symbol(False)) => Symbol(True)
         case _ => d
       ).asInstanceOf[T]
@@ -89,8 +89,8 @@ object CNFSimplification:
       * @return o if cnf is a negative Literal, d otherwise
       */
     def g[V <: CNF](e: V, o: V, d: V): V = e match
-      case Symbol(Variable(name, _)) if name == constr.name && !constr.value => o
-      case Not(Symbol(Variable(name, _))) if name == constr.name && constr.value => o
+      case Symbol(name: String) if name == constr.name && !constr.value => o
+      case Not(Symbol(name: String)) if name == constr.name && constr.value => o
       case Not(Symbol(True)) => o
       case Symbol(False) => o
       case _ => d
@@ -172,7 +172,7 @@ object CNFSimplification:
     */
   private def updateCnf[T <: CNF](cnf: T, constr: Constraint): T =
     (cnf match
-      case Symbol(variable: Variable) if variable.name == constr.name =>
+      case Symbol(name: String) if name == constr.name =>
         if constr.value then Symbol(True)
         else Symbol(False)
       case And(left, right) => And(updateCnf(left, constr), updateCnf(right, constr))

--- a/src/main/scala/satify/update/solver/dpll/utils/PartialModelUtils.scala
+++ b/src/main/scala/satify/update/solver/dpll/utils/PartialModelUtils.scala
@@ -4,8 +4,8 @@ import satify.model.Bool.True
 import satify.model.CNF.*
 import satify.model.dpll.DecisionTree.{Branch, Leaf}
 import satify.model.dpll.OrderedSeq.*
-import satify.model.dpll.{Constraint, Decision, DecisionTree, PartialModel}
-import satify.model.{CNF, Variable}
+import satify.model.dpll.{Constraint, Decision, DecisionTree, PartialModel, Variable}
+import satify.model.CNF
 
 object PartialModelUtils:
 
@@ -18,7 +18,7 @@ object PartialModelUtils:
     */
   def extractModelFromCnf(cnf: CNF): PartialModel =
     cnf match
-      case Symbol(variable: Variable) => seq(variable)
+      case Symbol(name: String) => seq(Variable(name))
       case And(e1, e2) => seq(extractModelFromCnf(e1) ++ extractModelFromCnf(e2): _*)
       case Or(e1, e2) => seq(extractModelFromCnf(e1) ++ extractModelFromCnf(e2): _*)
       case Not(e) => extractModelFromCnf(e)

--- a/src/test/scala/satify/ExpressionUtilsTest/ReplaceTest.scala
+++ b/src/test/scala/satify/ExpressionUtilsTest/ReplaceTest.scala
@@ -2,7 +2,6 @@ package satify.ExpressionUtilsTest
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import satify.model.Variable
 import satify.model.expression.Expression
 import satify.model.expression.Expression.*
 

--- a/src/test/scala/satify/ExpressionUtilsTest/SubexpressionsTest.scala
+++ b/src/test/scala/satify/ExpressionUtilsTest/SubexpressionsTest.scala
@@ -2,7 +2,6 @@ package satify.ExpressionUtilsTest
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import satify.model.Variable
 import satify.model.expression.Expression
 import satify.model.expression.Expression.*
 

--- a/src/test/scala/satify/parser/DimacsTest.scala
+++ b/src/test/scala/satify/parser/DimacsTest.scala
@@ -20,12 +20,7 @@ class DimacsTest extends AnyFlatSpec with Matchers {
       "c a comment", "c another comment", "p cnf 3 2", "1 2 0", "3 -1 0"
     )
     DimacsCNF.parse(lines) shouldBe
-      Some(
-        And(
-          Or(Symbol(Variable("x_1")), Symbol(Variable("x_2"))),
-          Or(Symbol(Variable("x_3")), Not(Symbol(Variable("x_1"))))
-        )
-      )
+      Some(And(Or(Not(Symbol("x_1")), Symbol("x_3")), Or(Symbol("x_2"), Symbol("x_1"))))
   }
 
   "DimacsCNF" should "open a DIMACS file and parse it" in {

--- a/src/test/scala/satify/problems/NQueensTest.scala
+++ b/src/test/scala/satify/problems/NQueensTest.scala
@@ -12,7 +12,7 @@ import satify.update.solver.{Solver, SolverType}
 
 class NQueensTest extends AnyFlatSpec with Matchers:
 
-  /*"NQueens 3x3" should "be UNSAT" in {
+  "NQueens 3x3" should "be UNSAT" in {
     val n = 3
     val sol = Solver(DPLL).solve(NQueens(n).exp)
     sol should matchPattern { case Solution(UNSAT, _) => }
@@ -26,7 +26,7 @@ class NQueensTest extends AnyFlatSpec with Matchers:
     printNqueens(n, sol.assignment.head.parModel)
   }
 
-  "NQueens 10x10" should "be SAT" in {
+  /*"NQueens 10x10" should "be SAT" in {
     val oCnf = DimacsCNF.read("src/main/resources/cnf/nqueens10.txt")
     oCnf should matchPattern { case Some(_) => }
     val sol = Solver(DPLL).solve(oCnf.get)
@@ -34,7 +34,6 @@ class NQueensTest extends AnyFlatSpec with Matchers:
     println("NQueens 10x10")
     printNQueensFromDimacs(10, sol.assignment.head.parModel)
   }
-  */
 
   "NQueens 15x15" should "be SAT" in {
     val oCnf = DimacsCNF.read("src/main/resources/cnf/nqueens20.txt")
@@ -43,4 +42,4 @@ class NQueensTest extends AnyFlatSpec with Matchers:
     sol should matchPattern { case Solution(SAT, _) => }
     println("NQueens 15x15")
     printNQueensFromDimacs(15, sol.assignment.head.parModel)
-  }
+  }*/

--- a/src/test/scala/satify/problems/NQueensTest.scala
+++ b/src/test/scala/satify/problems/NQueensTest.scala
@@ -12,7 +12,7 @@ import satify.update.solver.{Solver, SolverType}
 
 class NQueensTest extends AnyFlatSpec with Matchers:
 
-  "NQueens 3x3" should "be UNSAT" in {
+  /*"NQueens 3x3" should "be UNSAT" in {
     val n = 3
     val sol = Solver(DPLL).solve(NQueens(n).exp)
     sol should matchPattern { case Solution(UNSAT, _) => }
@@ -26,7 +26,7 @@ class NQueensTest extends AnyFlatSpec with Matchers:
     printNqueens(n, sol.assignment.head.parModel)
   }
 
-  /*"NQueens 10x10" should "be SAT" in {
+  "NQueens 10x10" should "be SAT" in {
     val oCnf = DimacsCNF.read("src/main/resources/cnf/nqueens10.txt")
     oCnf should matchPattern { case Some(_) => }
     val sol = Solver(DPLL).solve(oCnf.get)
@@ -34,6 +34,7 @@ class NQueensTest extends AnyFlatSpec with Matchers:
     println("NQueens 10x10")
     printNQueensFromDimacs(10, sol.assignment.head.parModel)
   }
+  */
 
   "NQueens 15x15" should "be SAT" in {
     val oCnf = DimacsCNF.read("src/main/resources/cnf/nqueens20.txt")
@@ -42,4 +43,4 @@ class NQueensTest extends AnyFlatSpec with Matchers:
     sol should matchPattern { case Solution(SAT, _) => }
     println("NQueens 15x15")
     printNQueensFromDimacs(15, sol.assignment.head.parModel)
-  }*/
+  }

--- a/src/test/scala/satify/update/converters/CNFConverter.scala
+++ b/src/test/scala/satify/update/converters/CNFConverter.scala
@@ -5,7 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.{And as CNFAnd, Not as CNFNot, Or as CNFOr, Symbol as CNFSymbol}
 import satify.model.expression.Expression
 import satify.model.expression.Expression.*
-import satify.model.{CNF, Variable}
+import satify.model.CNF
+import satify.model.dpll.Variable
 import satify.update.converters.TseitinTransformation.convertToCNF
 
 class CNFConverter extends AnyFlatSpec with Matchers:
@@ -13,7 +14,7 @@ class CNFConverter extends AnyFlatSpec with Matchers:
   "The exp a and b" should "be converted to CNF" in {
     val exp: Expression = And(Symbol("a"), Symbol("b"))
     val result: CNF = convertToCNF(exp)
-    val expected: CNF = CNFAnd(CNFSymbol(Variable("a")), CNFSymbol(Variable("b")))
+    val expected: CNF = CNFAnd(CNFSymbol("a"), CNFSymbol("b"))
     result shouldBe expected
   }
 
@@ -21,14 +22,14 @@ class CNFConverter extends AnyFlatSpec with Matchers:
     val exp: Expression = And(Symbol("a"), And(Symbol("b"), And(Symbol("c"), And(Symbol("d"), Symbol("e")))))
     val result: CNF = convertToCNF(exp)
     val expected: CNF = CNFAnd(
-      CNFSymbol(Variable("a")),
+      CNFSymbol("a"),
       CNFAnd(
-        CNFSymbol(Variable("b")),
+        CNFSymbol("b"),
         CNFAnd(
-          CNFSymbol(Variable("c")),
+          CNFSymbol("c"),
           CNFAnd(
-            CNFSymbol(Variable("d")),
-            CNFSymbol(Variable("e"))
+            CNFSymbol("d"),
+            CNFSymbol("e")
           )
         )
       )
@@ -81,34 +82,34 @@ class CNFConverter extends AnyFlatSpec with Matchers:
     val result: CNF = convertToCNF(exp)
     val expected = CNFAnd(
       CNFOr(
-        CNFOr(CNFSymbol(Variable("TSTN1")), CNFSymbol(Variable("d"))),
-        CNFNot(CNFSymbol(Variable("TSTN0")))
+        CNFOr(CNFSymbol("TSTN1"), CNFSymbol("d")),
+        CNFNot(CNFSymbol("TSTN0"))
       ),
       CNFAnd(
-        CNFOr(CNFNot(CNFSymbol(Variable("TSTN1"))), CNFSymbol(Variable("TSTN0"))),
+        CNFOr(CNFNot(CNFSymbol("TSTN1")), CNFSymbol("TSTN0")),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol(Variable("d"))), CNFSymbol(Variable("TSTN0"))),
+          CNFOr(CNFNot(CNFSymbol("d")), CNFSymbol("TSTN0")),
           CNFAnd(
             CNFOr(
-              CNFOr(CNFSymbol(Variable("TSTN2")), CNFSymbol(Variable("TSTN3"))),
-              CNFNot(CNFSymbol(Variable("TSTN1")))
+              CNFOr(CNFSymbol("TSTN2"), CNFSymbol("TSTN3")),
+              CNFNot(CNFSymbol("TSTN1"))
             ),
             CNFAnd(
-              CNFOr(CNFNot(CNFSymbol(Variable("TSTN2"))), CNFSymbol(Variable("TSTN1"))),
+              CNFOr(CNFNot(CNFSymbol("TSTN2")), CNFSymbol("TSTN1")),
               CNFAnd(
-                CNFOr(CNFNot(CNFSymbol(Variable("TSTN3"))), CNFSymbol(Variable("TSTN1"))),
+                CNFOr(CNFNot(CNFSymbol("TSTN3")), CNFSymbol("TSTN1")),
                 CNFAnd(
-                  CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("TSTN2")))),
+                  CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN2"))),
                   CNFAnd(
-                    CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("TSTN2"))),
+                    CNFOr(CNFSymbol("a"), CNFSymbol("TSTN2")),
                     CNFAnd(
                       CNFOr(
-                        CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("c")))),
-                        CNFSymbol(Variable("TSTN3"))
+                        CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("c"))),
+                        CNFSymbol("TSTN3")
                       ),
                       CNFAnd(
-                        CNFOr(CNFSymbol(Variable("b")), CNFNot(CNFSymbol(Variable("TSTN3")))),
-                        CNFOr(CNFSymbol(Variable("c")), CNFNot(CNFSymbol(Variable("TSTN3"))))
+                        CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN3"))),
+                        CNFOr(CNFSymbol("c"), CNFNot(CNFSymbol("TSTN3")))
                       )
                     )
                   )

--- a/src/test/scala/satify/update/converters/CNFOutputTest.scala
+++ b/src/test/scala/satify/update/converters/CNFOutputTest.scala
@@ -3,12 +3,12 @@ package satify.update.converters
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.*
-import satify.model.{CNF, Variable}
+import satify.model.{CNF}
 
 class CNFOutputTest extends AnyFlatSpec with Matchers:
 
   "The cnf symbol a" should "be printed as a in formal way" in {
-    val cnfExp: CNF = Symbol(Variable("a"))
+    val cnfExp: CNF = Symbol("a")
     val fRes: String = cnfExp.printAsFormal(true)
     val nfRes: String = cnfExp.printAsFormal()
     val expected = "a"
@@ -17,7 +17,7 @@ class CNFOutputTest extends AnyFlatSpec with Matchers:
 
   "The cnf exp ((a ∨ ¬b) ∧ c)" should "be printed in the formal way and according to the output flat mode" in {
     val cnfExp: CNF =
-      And(Or(Symbol(Variable("a")), Not(Symbol(Variable("b")))), Symbol(Variable("c")))
+      And(Or(Symbol("a"), Not(Symbol("b"))), Symbol("c"))
     val fRes: String = cnfExp.printAsFormal(true)
     val fExp: String = "a ∨ ¬(b) ∧ c"
     val nfRes: String = cnfExp.printAsFormal()
@@ -26,7 +26,7 @@ class CNFOutputTest extends AnyFlatSpec with Matchers:
   }
 
   "The only symbol a" should "be printed as a in DSL" in {
-    val exp: CNF = Symbol(Variable("a"))
+    val exp: CNF = Symbol("a")
     val fRes: String = exp.printAsDSL(true)
     val nfRes: String = exp.printAsDSL()
     val expected = "a"
@@ -35,7 +35,7 @@ class CNFOutputTest extends AnyFlatSpec with Matchers:
 
   "The exp ((a ∨ ¬b) ∧ c)" should "be printed in the DSL format according to the output flat mode" in {
     val exp: CNF =
-      And(Or(Symbol(Variable("a")), Not(Symbol(Variable("b")))), Symbol(Variable("c")))
+      And(Or(Symbol("a"), Not(Symbol("b"))), Symbol("c"))
     val fRes: String = exp.printAsDSL(true)
     val fExp = "a or not(b) and c"
     val nfRes: String = exp.printAsDSL()

--- a/src/test/scala/satify/update/converters/CNFOutputTest.scala
+++ b/src/test/scala/satify/update/converters/CNFOutputTest.scala
@@ -3,7 +3,7 @@ package satify.update.converters
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.*
-import satify.model.{CNF}
+import satify.model.CNF
 
 class CNFOutputTest extends AnyFlatSpec with Matchers:
 

--- a/src/test/scala/satify/update/converters/TseitinTest.scala
+++ b/src/test/scala/satify/update/converters/TseitinTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.{And as CNFAnd, Not as CNFNot, Or as CNFOr, Symbol as CNFSymbol}
 import satify.model.expression.Expression.*
-import satify.model.{CNF, Variable}
+import satify.model.CNF
 import satify.update.converters.TseitinTransformation.tseitin
 
 class TseitinTest extends AnyFlatSpec with Matchers:
@@ -12,7 +12,7 @@ class TseitinTest extends AnyFlatSpec with Matchers:
   "The CNF form of b" should "remain b" in {
     val exp = Symbol("b")
     val result = tseitin(exp)
-    val expected: CNF = CNFSymbol(Variable("b"))
+    val expected: CNF = CNFSymbol("b")
     result shouldBe expected
   }
 
@@ -20,10 +20,10 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Not(Symbol("b"))
     val result = tseitin(exp)
     val expected: CNF = CNFAnd(
-      CNFSymbol(Variable("TSTN0")),
+      CNFSymbol("TSTN0"),
       CNFAnd(
-        CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("TSTN0")))),
-        CNFOr(CNFSymbol(Variable("b")), CNFSymbol(Variable("TSTN0")))
+        CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0"))),
+        CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
       )
     )
     result shouldBe expected
@@ -33,15 +33,15 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Or(Symbol("a"), Symbol("b"))
     val result = tseitin(exp)
     val expected: CNF = CNFAnd(
-      CNFSymbol(Variable("TSTN0")),
+      CNFSymbol("TSTN0"),
       CNFAnd(
         CNFOr(
-          CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("b"))),
-          CNFNot(CNFSymbol(Variable("TSTN0")))
+          CNFOr(CNFSymbol("a"), CNFSymbol("b")),
+          CNFNot(CNFSymbol("TSTN0"))
         ),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFSymbol(Variable("TSTN0"))),
-          CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFSymbol(Variable("TSTN0")))
+          CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("TSTN0")),
+          CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("TSTN0"))
         )
       )
     )
@@ -52,28 +52,28 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Or(And(Symbol("a"), Not(Symbol("b"))), Symbol("c"))
     val result = tseitin(exp)
     val expected = CNFAnd(
-      CNFSymbol(Variable("TSTN0")),
+      CNFSymbol("TSTN0"),
       CNFAnd(
         CNFOr(
-          CNFOr(CNFSymbol(Variable("TSTN1")), CNFSymbol(Variable("c"))),
-          CNFNot(CNFSymbol(Variable("TSTN0")))
+          CNFOr(CNFSymbol("TSTN1"), CNFSymbol("c")),
+          CNFNot(CNFSymbol("TSTN0"))
         ),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol(Variable("TSTN1"))), CNFSymbol(Variable("TSTN0"))),
+          CNFOr(CNFNot(CNFSymbol("TSTN1")), CNFSymbol("TSTN0")),
           CNFAnd(
-            CNFOr(CNFNot(CNFSymbol(Variable("c"))), CNFSymbol(Variable("TSTN0"))),
+            CNFOr(CNFNot(CNFSymbol("c")), CNFSymbol("TSTN0")),
             CNFAnd(
               CNFOr(
-                CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("TSTN2")))),
-                CNFSymbol(Variable("TSTN1"))
+                CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN2"))),
+                CNFSymbol("TSTN1")
               ),
               CNFAnd(
-                CNFOr(CNFSymbol(Variable("a")), CNFNot(CNFSymbol(Variable("TSTN1")))),
+                CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("TSTN1"))),
                 CNFAnd(
-                  CNFOr(CNFSymbol(Variable("TSTN2")), CNFNot(CNFSymbol(Variable("TSTN1")))),
+                  CNFOr(CNFSymbol("TSTN2"), CNFNot(CNFSymbol("TSTN1"))),
                   CNFAnd(
-                    CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("TSTN2")))),
-                    CNFOr(CNFSymbol(Variable("b")), CNFSymbol(Variable("TSTN2")))
+                    CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN2"))),
+                    CNFOr(CNFSymbol("b"), CNFSymbol("TSTN2"))
                   )
                 )
               )
@@ -89,34 +89,34 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Or(Or(Not(Symbol("a")), And(Symbol("b"), Symbol("c"))), Symbol("d"))
     val result = tseitin(exp)
     val expected = CNFAnd(
-      CNFSymbol(Variable("TSTN0")),
+      CNFSymbol("TSTN0"),
       CNFAnd(
-        CNFOr(CNFOr(CNFSymbol(Variable("TSTN1")), CNFSymbol(Variable("d"))), CNFNot(CNFSymbol(Variable("TSTN0")))),
+        CNFOr(CNFOr(CNFSymbol("TSTN1"), CNFSymbol("d")), CNFNot(CNFSymbol("TSTN0"))),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol(Variable("TSTN1"))), CNFSymbol(Variable("TSTN0"))),
+          CNFOr(CNFNot(CNFSymbol("TSTN1")), CNFSymbol("TSTN0")),
           CNFAnd(
-            CNFOr(CNFNot(CNFSymbol(Variable("d"))), CNFSymbol(Variable("TSTN0"))),
+            CNFOr(CNFNot(CNFSymbol("d")), CNFSymbol("TSTN0")),
             CNFAnd(
               CNFOr(
-                CNFOr(CNFSymbol(Variable("TSTN2")), CNFSymbol(Variable("TSTN3"))),
-                CNFNot(CNFSymbol(Variable("TSTN1")))
+                CNFOr(CNFSymbol("TSTN2"), CNFSymbol("TSTN3")),
+                CNFNot(CNFSymbol("TSTN1"))
               ),
               CNFAnd(
-                CNFOr(CNFNot(CNFSymbol(Variable("TSTN2"))), CNFSymbol(Variable("TSTN1"))),
+                CNFOr(CNFNot(CNFSymbol("TSTN2")), CNFSymbol("TSTN1")),
                 CNFAnd(
-                  CNFOr(CNFNot(CNFSymbol(Variable("TSTN3"))), CNFSymbol(Variable("TSTN1"))),
+                  CNFOr(CNFNot(CNFSymbol("TSTN3")), CNFSymbol("TSTN1")),
                   CNFAnd(
-                    CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("TSTN2")))),
+                    CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN2"))),
                     CNFAnd(
-                      CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("TSTN2"))),
+                      CNFOr(CNFSymbol("a"), CNFSymbol("TSTN2")),
                       CNFAnd(
                         CNFOr(
-                          CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("c")))),
-                          CNFSymbol(Variable("TSTN3"))
+                          CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("c"))),
+                          CNFSymbol("TSTN3")
                         ),
                         CNFAnd(
-                          CNFOr(CNFSymbol(Variable("b")), CNFNot(CNFSymbol(Variable("TSTN3")))),
-                          CNFOr(CNFSymbol(Variable("c")), CNFNot(CNFSymbol(Variable("TSTN3"))))
+                          CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN3"))),
+                          CNFOr(CNFSymbol("c"), CNFNot(CNFSymbol("TSTN3")))
                         )
                       )
                     )

--- a/src/test/scala/satify/update/converters/TseitinTransformationTest.scala
+++ b/src/test/scala/satify/update/converters/TseitinTransformationTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.{Not as CNFNot, Or as CNFOr, Symbol as CNFSymbol}
 import satify.model.expression.Expression
 import satify.model.expression.Expression.*
-import satify.model.{CNF, Variable}
+import satify.model.CNF
 import satify.update.converters.TseitinTransformation.transform
 
 class TseitinTransformationTest extends AnyFlatSpec with Matchers:
@@ -24,8 +24,8 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val exp: (Symbol, Expression) = (Symbol("TSTN0"), Not(Symbol("b")))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
-      CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("TSTN0")))),
-      CNFOr(CNFSymbol(Variable("b")), CNFSymbol(Variable("TSTN0")))
+      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0"))),
+      CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
     )
     result shouldBe expected
   }
@@ -35,11 +35,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("b")))),
-        CNFSymbol(Variable("TSTN0"))
+        CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("b"))),
+        CNFSymbol("TSTN0")
       ),
-      CNFOr(CNFSymbol(Variable("a")), CNFNot(CNFSymbol(Variable("TSTN0")))),
-      CNFOr(CNFSymbol(Variable("b")), CNFNot(CNFSymbol(Variable("TSTN0"))))
+      CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("TSTN0"))),
+      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN0")))
     )
     result shouldBe expected
   }
@@ -49,11 +49,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFSymbol(Variable("a")), CNFNot(CNFSymbol(Variable("b")))),
-        CNFSymbol(Variable("TSTN0"))
+        CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("b"))),
+        CNFSymbol("TSTN0")
       ),
-      CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("TSTN0")))),
-      CNFOr(CNFSymbol(Variable("b")), CNFNot(CNFSymbol(Variable("TSTN0"))))
+      CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN0"))),
+      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN0")))
     )
     result shouldBe expected
   }
@@ -63,11 +63,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFSymbol(Variable("b"))),
-        CNFSymbol(Variable("TSTN0"))
+        CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("b")),
+        CNFSymbol("TSTN0")
       ),
-      CNFOr(CNFSymbol(Variable("a")), CNFNot(CNFSymbol(Variable("TSTN0")))),
-      CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("TSTN0"))))
+      CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("TSTN0"))),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0")))
     )
     result shouldBe expected
   }
@@ -76,9 +76,9 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val exp: (Symbol, Expression) = (Symbol("TSTN0"), And(Not(Symbol("a")), Not(Symbol("b"))))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
-      CNFOr(CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("b"))), CNFSymbol(Variable("TSTN0"))),
-      CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("TSTN0")))),
-      CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFNot(CNFSymbol(Variable("TSTN0"))))
+      CNFOr(CNFOr(CNFSymbol("a"), CNFSymbol("b")), CNFSymbol("TSTN0")),
+      CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN0"))),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0")))
     )
     result shouldBe expected
   }
@@ -88,11 +88,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("b"))),
-        CNFNot(CNFSymbol(Variable("TSTN0")))
+        CNFOr(CNFSymbol("a"), CNFSymbol("b")),
+        CNFNot(CNFSymbol("TSTN0"))
       ),
-      CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFSymbol(Variable("TSTN0"))),
-      CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFSymbol(Variable("TSTN0")))
+      CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("TSTN0")),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("TSTN0"))
     )
     result shouldBe expected
   }
@@ -102,11 +102,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFSymbol(Variable("b"))),
-        CNFNot(CNFSymbol(Variable("TSTN0")))
+        CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("b")),
+        CNFNot(CNFSymbol("TSTN0"))
       ),
-      CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("TSTN0"))),
-      CNFOr(CNFNot(CNFSymbol(Variable("b"))), CNFSymbol(Variable("TSTN0")))
+      CNFOr(CNFSymbol("a"), CNFSymbol("TSTN0")),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("TSTN0"))
     )
     result shouldBe expected
   }
@@ -116,11 +116,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFSymbol(Variable("a")), CNFNot(CNFSymbol(Variable("b")))),
-        CNFNot(CNFSymbol(Variable("TSTN0")))
+        CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("b"))),
+        CNFNot(CNFSymbol("TSTN0"))
       ),
-      CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFSymbol(Variable("TSTN0"))),
-      CNFOr(CNFSymbol(Variable("b")), CNFSymbol(Variable("TSTN0")))
+      CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("TSTN0")),
+      CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
     )
     result shouldBe expected
   }
@@ -130,11 +130,11 @@ class TseitinTransformationTest extends AnyFlatSpec with Matchers:
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
-        CNFOr(CNFNot(CNFSymbol(Variable("a"))), CNFNot(CNFSymbol(Variable("b")))),
-        CNFNot(CNFSymbol(Variable("TSTN0")))
+        CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("b"))),
+        CNFNot(CNFSymbol("TSTN0"))
       ),
-      CNFOr(CNFSymbol(Variable("a")), CNFSymbol(Variable("TSTN0"))),
-      CNFOr(CNFSymbol(Variable("b")), CNFSymbol(Variable("TSTN0")))
+      CNFOr(CNFSymbol("a"), CNFSymbol("TSTN0")),
+      CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
     )
     result shouldBe expected
   }

--- a/src/test/scala/satify/update/converters/VariableSubstitutionTest.scala
+++ b/src/test/scala/satify/update/converters/VariableSubstitutionTest.scala
@@ -2,7 +2,6 @@ package satify.update.converters
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import satify.model.Variable
 import satify.model.expression.Expression
 import satify.model.expression.Expression.*
 import satify.update.converters.TseitinTransformation.symbolsReplace

--- a/src/test/scala/satify/update/solver/dpll/CNFSatTest.scala
+++ b/src/test/scala/satify/update/solver/dpll/CNFSatTest.scala
@@ -9,7 +9,7 @@ import satify.update.solver.dpll.cnf.CNFSimplification.simplifyCnf
 import satify.update.solver.dpll.cnf.CNFSat.isUnsat
 
 class CNFSatTest extends AnyFlatSpec with Matchers:
-  
+
   val sA: Symbol = Symbol("a")
   val sB: Symbol = Symbol("b")
   val sC: Symbol = Symbol("c")

--- a/src/test/scala/satify/update/solver/dpll/CNFSatTest.scala
+++ b/src/test/scala/satify/update/solver/dpll/CNFSatTest.scala
@@ -3,31 +3,31 @@ package satify.update.solver.dpll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.{And, Not, Or, Symbol}
-import satify.model.dpll.Constraint
-import satify.model.{CNF, Variable}
+import satify.model.dpll.{Constraint, Variable}
+import satify.model.CNF
 import satify.update.solver.dpll.cnf.CNFSimplification.simplifyCnf
 import satify.update.solver.dpll.cnf.CNFSat.isUnsat
 
 class CNFSatTest extends AnyFlatSpec with Matchers:
+  
+  val sA: Symbol = Symbol("a")
+  val sB: Symbol = Symbol("b")
+  val sC: Symbol = Symbol("c")
 
-  val varA: Variable = Variable("a")
-  val varB: Variable = Variable("b")
-  val varC: Variable = Variable("c")
-
-  val cnf: CNF = And(Or(Symbol(varA), Or(Symbol(varB), Not(Symbol(varA)))), Symbol(varC))
+  val cnf: CNF = And(Or(sA, Or(sB, Not(sA))), sC)
 
   "Expressions in CNF" should "not be UNSAT" in {
     isUnsat(simplifyCnf(cnf, Constraint("c", true))) shouldBe false
-    val cnfOr = Or(Symbol(varA), Or(Symbol(varB), Not(Symbol(varC))))
+    val cnfOr = Or(sA, Or(sB, Not(sC)))
     isUnsat(simplifyCnf(cnfOr, Constraint("c", true))) shouldBe false
-    val cnfPosLit = Symbol(varA)
+    val cnfPosLit = sA
     isUnsat(simplifyCnf(cnfPosLit, Constraint("a", true))) shouldBe false
-    val cnfNegLit = Not(Symbol(varB))
+    val cnfNegLit = Not(sB)
     isUnsat(simplifyCnf(cnfNegLit, Constraint("b", false))) shouldBe false
   }
 
   "Expressions in CNF" should "be UNSAT" in {
     isUnsat(simplifyCnf(cnf, Constraint("c", false))) shouldBe true
-    val anCnf = And(Symbol(varA), Or(Symbol(varB), Symbol(varB)))
+    val anCnf = And(sA, Or(sB, sB))
     isUnsat(simplifyCnf(anCnf, Constraint("b", false))) shouldBe true
   }

--- a/src/test/scala/satify/update/solver/dpll/CNFSimplificationTest.scala
+++ b/src/test/scala/satify/update/solver/dpll/CNFSimplificationTest.scala
@@ -5,71 +5,71 @@ import org.scalatest.matchers.should.Matchers
 import satify.model.Bool.{False, True}
 import satify.model.CNF.*
 import satify.model.dpll.Constraint
-import satify.model.{CNF, Variable}
+import satify.model.CNF
 import satify.update.solver.dpll.cnf.CNFSimplification.*
 
 class CNFSimplificationTest extends AnyFlatSpec with Matchers:
 
-  val varA: Variable = Variable("a")
-  val varB: Variable = Variable("b")
-  val varC: Variable = Variable("c")
+  val sA: Symbol = Symbol("a")
+  val sB: Symbol = Symbol("b")
+  val sC: Symbol = Symbol("c")
 
-  val cnf: CNF = And(Or(Symbol(varA), Symbol(varB)), Symbol(varC))
+  val cnf: CNF = And(Or(sA, sB), sC)
 
   "An expression in CNF" should "be simplified when a Literal inside a clause is set to true" in {
     val posLitCnf = cnf
-    simplifyCnf(posLitCnf, Constraint("a", true)) shouldBe Symbol(varC)
-    val negLitCnf: CNF = And(Or(Symbol(varA), Or(Not(Symbol(varB)), Symbol(varC))), Symbol(varC))
-    simplifyCnf(negLitCnf, Constraint("b", false)) shouldBe Symbol(varC)
+    simplifyCnf(posLitCnf, Constraint("a", true)) shouldBe sC
+    val negLitCnf: CNF = And(Or(sA, Or(Not(sB), sC)), sC)
+    simplifyCnf(negLitCnf, Constraint("b", false)) shouldBe sC
   }
 
   "An expression in CNF" should "be simplified for each occurrence of the constrained Literal" in {
-    val cnf = And(Or(Symbol(varA), Symbol(varB)), And(Or(Symbol(varC), Or(Symbol(varA), Symbol(varB))), Symbol(varC)))
-    simplifyCnf(cnf, Constraint("a", true)) shouldBe Symbol(varC)
+    val cnf = And(Or(sA, sB), And(Or(sC, Or(sA, sB)), sC))
+    simplifyCnf(cnf, Constraint("a", true)) shouldBe sC
   }
 
   "An expression in CNF" should "be simplified only on the branches where the Literal is found" in {
-    val cnf: CNF = And(Or(Symbol(varA), Or(Not(Symbol(varB)), Symbol(varC))), Or(Symbol(varA), Symbol(varC)))
-    simplifyCnf(cnf, Constraint("b", false)) shouldBe Or(Symbol(varA), Symbol(varC))
+    val cnf: CNF = And(Or(sA, Or(Not(sB), sC)), Or(sA, sC))
+    simplifyCnf(cnf, Constraint("b", false)) shouldBe Or(sA, sC)
   }
 
   "An expression in CNF" should "be simplified when a Literal inside a clause is set to false" in {
     val posLitCnf = cnf
-    simplifyCnf(posLitCnf, Constraint("a", false)) shouldBe And(Symbol(varB), Symbol(varC))
-    val negLitCnf: CNF = And(Or(Symbol(varA), Not(Symbol(varB))), Symbol(varC))
-    simplifyCnf(negLitCnf, Constraint("b", true)) shouldBe And(Symbol(varA), Symbol(varC))
-    val complexCnf = And(Or(Symbol(varA), Or(Symbol(varA), Symbol(varB))), Symbol(varC))
-    simplifyCnf(complexCnf, Constraint("a", false)) shouldBe And(Symbol(varB), Symbol(varC))
-    val complexCnf1 = And(Or(Symbol(varA), Or(Symbol(varA), Or(Symbol(varB), Symbol(varC)))), Symbol(varC))
-    simplifyCnf(complexCnf1, Constraint("a", false)) shouldBe And(Or(Symbol(varB), Symbol(varC)), Symbol(varC))
+    simplifyCnf(posLitCnf, Constraint("a", false)) shouldBe And(sB, sC)
+    val negLitCnf: CNF = And(Or(sA, Not(sB)), sC)
+    simplifyCnf(negLitCnf, Constraint("b", true)) shouldBe And(sA, sC)
+    val complexCnf = And(Or(sA, Or(sA, sB)), sC)
+    simplifyCnf(complexCnf, Constraint("a", false)) shouldBe And(sB, sC)
+    val complexCnf1 = And(Or(sA, Or(sA, Or(sB, sC))), sC)
+    simplifyCnf(complexCnf1, Constraint("a", false)) shouldBe And(Or(sB, sC), sC)
   }
 
   "An expression in CNF" should "be simplified when an And contains all true Literals" in {
-    val cnf = And(Symbol(varA), Symbol(True))
+    val cnf = And(sA, Symbol(True))
     simplifyCnf(cnf, Constraint("a", true)) shouldBe Symbol(True)
   }
 
   "An expression in CNF" should "be simplified when an And contains at least a True Literal" in {
-    val cnf = And(Symbol(True), And(Symbol(varB), Symbol(varC)))
-    simplifyCnf(cnf, Constraint("b", true)) shouldBe Symbol(varC)
-    val complexCnf = And(Symbol(varA), And(Symbol(varB), And(Symbol(varA), Symbol(varC))))
-    simplifyCnf(complexCnf, Constraint("a", true)) shouldBe And(Symbol(varB), Symbol(varC))
+    val cnf = And(Symbol(True), And(sB, sC))
+    simplifyCnf(cnf, Constraint("b", true)) shouldBe sC
+    val complexCnf = And(sA, And(sB, And(sA, sC)))
+    simplifyCnf(complexCnf, Constraint("a", true)) shouldBe And(sB, sC)
   }
 
   "An expression in CNF" should "be simplified when a Literal appears in positive and negative form" in {
-    val cnf = And(Symbol(varA), Or(Symbol(varB), Or(Symbol(varC), Not(Symbol(varA)))))
-    simplifyCnf(cnf, Constraint("a", true)) shouldBe Or(Symbol(varB), Symbol(varC))
-    val complexCnf = And(Not(Symbol(varA)), Or(Symbol(varB), Or(Not(Symbol(varA)), Not(Symbol(varA)))))
+    val cnf = And(sA, Or(sB, Or(sC, Not(sA))))
+    simplifyCnf(cnf, Constraint("a", true)) shouldBe Or(sB, sC)
+    val complexCnf = And(Not(sA), Or(sB, Or(Not(sA), Not(sA))))
     simplifyCnf(complexCnf, Constraint("a", false)) shouldBe Symbol(True)
-    val complexCnf1 = And(Symbol(varA), Or(Symbol(varB), Or(Not(Symbol(varA)), Not(Symbol(varA)))))
+    val complexCnf1 = And(sA, Or(sB, Or(Not(sA), Not(sA))))
     simplifyCnf(complexCnf1, Constraint("a", false)) shouldBe Symbol(False)
   }
 
   "An expression in CNF" should "be simplified when it contains only Or(s) or Literal(s)" in {
-    val cnfOr = Or(Not(Symbol(varA)), Or(Or(Symbol(varB), Not(Symbol(varA))), Not(Symbol(varC))))
+    val cnfOr = Or(Not(sA), Or(Or(sB, Not(sA)), Not(sC)))
     simplifyCnf(cnfOr, Constraint("a", false)) shouldBe Symbol(True)
-    simplifyCnf(cnfOr, Constraint("a", true)) shouldBe Or(Symbol(varB), Not(Symbol(varC)))
-    val cnfLit = Not(Symbol(varA))
+    simplifyCnf(cnfOr, Constraint("a", true)) shouldBe Or(sB, Not(sC))
+    val cnfLit = Not(sA)
     simplifyCnf(cnfLit, Constraint("a", false)) shouldBe Symbol(True)
     simplifyCnf(cnfLit, Constraint("a", true)) shouldBe Symbol(False)
   }

--- a/src/test/scala/satify/update/solver/dpll/PartialModelUtilsTest.scala
+++ b/src/test/scala/satify/update/solver/dpll/PartialModelUtilsTest.scala
@@ -4,8 +4,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import satify.model.CNF.*
 import satify.model.dpll.OrderedSeq.{given_Ordering_Variable, seq}
-import satify.model.dpll.{Constraint, Decision, PartialModel}
-import satify.model.{CNF, Variable}
+import satify.model.dpll.{Constraint, Decision, PartialModel, Variable}
+import satify.model.CNF
 import satify.update.solver.dpll.Dpll.dpll
 import satify.update.solver.dpll.utils.PartialModelUtils.*
 
@@ -13,9 +13,8 @@ class PartialModelUtilsTest extends AnyFlatSpec with Matchers:
 
   val varA: Variable = Variable("a")
   val varB: Variable = Variable("b")
-  val varC: Variable = Variable("c")
 
-  val cnf: CNF = And(Symbol(varA), Symbol(varB))
+  val cnf: CNF = And(Symbol("a"), Symbol("b"))
 
   val Dpll: CNF => Set[PartialModel] = cnf =>
     val s =
@@ -26,7 +25,7 @@ class PartialModelUtilsTest extends AnyFlatSpec with Matchers:
   "A PartialModel" should "be extractable from a CNF" in {
     extractModelFromCnf(cnf) shouldBe seq(varA, varB)
     val allCnf: CNF =
-      And(Symbol(Variable("c")), And(Or(Symbol(Variable("d")), Not(Symbol(Variable("e")))), Symbol(Variable("f"))))
+      And(Symbol("c"), And(Or(Symbol("d"), Not(Symbol("e"))), Symbol("f")))
     extractModelFromCnf(allCnf) shouldBe seq(Variable("c"), Variable("d"), Variable("e"), Variable("f"))
   }
 
@@ -44,7 +43,7 @@ class PartialModelUtilsTest extends AnyFlatSpec with Matchers:
   "All solutions" should "be extractable from a DecisionTree" in {
     extractSolutionsFromDT(dpll(Decision(extractModelFromCnf(cnf), cnf))) shouldBe
       Set(seq(Variable("a", Some(true)), Variable("b", Some(true))))
-    Dpll(And(Symbol(varA), Or(Symbol(varB), Symbol(varC)))) shouldBe
+    Dpll(And(Symbol("a"), Or(Symbol("b"), Symbol("c")))) shouldBe
       Set(
         seq(Variable("a", Some(true)), Variable("b", Some(true)), Variable("c", Some(true))),
         seq(Variable("a", Some(true)), Variable("b", Some(true)), Variable("c", Some(false))),


### PR DESCRIPTION
Main changes:
- Tailrec functions in DIMACS parser;
- Replace Variable in CNF with a String | Bool. This is because when DPLL constraints a variable, the CNF will be simplified and so we'll never have the CNF with an assigned value.