### PR TITLE
Feature/tseitin-little-fix

### DIFF
--- a/src/main/scala/satify/model/dpll/PartialAssignment.scala
+++ b/src/main/scala/satify/model/dpll/PartialAssignment.scala
@@ -6,7 +6,7 @@ import satify.model.cnf.CNF.*
 import satify.model.dpll.*
 import satify.model.dpll.DecisionTree.{Branch, Leaf}
 import satify.model.dpll.OrderedList.list
-import satify.model.expression.SymbolGeneration.{encodingVarPrefix, tseitinVarPrefix}
+import satify.model.expression.SymbolGeneration.{encodingVarPrefix, converterVarPrefix}
 import satify.model.{Assignment, Variable}
 
 /** Represents an [[Assignment]] where the variables could not be yet constrained by the DPLL algorithm.
@@ -94,7 +94,7 @@ object PartialAssignment:
                 optVars.filter(v =>
                   v match
                     case OptionalVariable(name, _)
-                        if name.startsWith(tseitinVarPrefix) || name.startsWith(encodingVarPrefix) =>
+                        if name.startsWith(converterVarPrefix) || name.startsWith(encodingVarPrefix) =>
                       false
                     case _ => true
                 )

--- a/src/main/scala/satify/model/expression/SymbolGeneration.scala
+++ b/src/main/scala/satify/model/expression/SymbolGeneration.scala
@@ -5,7 +5,7 @@ import satify.model.expression.Expression.*
 object SymbolGeneration:
 
   val encodingVarPrefix = "ENC"
-  val tseitinVarPrefix = "TSTN"
+  val converterVarPrefix = "GEN"
 
   /** A generator of new Symbols starting from a prefix. */
   trait SymbolGenerator:

--- a/src/main/scala/satify/update/converters/tseitin/TseitinTransformation.scala
+++ b/src/main/scala/satify/update/converters/tseitin/TseitinTransformation.scala
@@ -2,7 +2,7 @@ package satify.update.converters.tseitin
 
 import satify.model.cnf.CNF
 import satify.model.expression.Expression
-import satify.model.expression.SymbolGeneration.tseitinVarPrefix
+import satify.model.expression.SymbolGeneration.converterVarPrefix
 
 import scala.annotation.tailrec
 
@@ -100,7 +100,7 @@ private[converters] object TseitinTransformation:
     if subexpressions.size == 1 then subexpressions.head
     else
       var concatenated = subexpressions
-      concatenated = concatenated.prepended(CNFSymbol(tseitinVarPrefix + "0"))
+      concatenated = concatenated.prepended(CNFSymbol(converterVarPrefix + "0"))
       concatenated.reduceRight((s1, s2) =>
         CNFAnd(s1.asInstanceOf[CNFOr | Literal], s2.asInstanceOf[CNFAnd | CNFOr | Literal])
       )

--- a/src/main/scala/satify/update/converters/tseitin/Utils.scala
+++ b/src/main/scala/satify/update/converters/tseitin/Utils.scala
@@ -4,7 +4,7 @@ import satify.model.cnf.CNF.{And as CNFAnd, Not as CNFNot, Or as CNFOr, Symbol a
 import satify.model.cnf.{CNF, Literal}
 import satify.model.expression.Expression
 import satify.model.expression.Expression.*
-import satify.model.expression.SymbolGeneration.{SymbolGenerator, tseitinVarPrefix}
+import satify.model.expression.SymbolGeneration.{SymbolGenerator, converterVarPrefix}
 
 private[converters] object Utils:
 
@@ -14,7 +14,7 @@ private[converters] object Utils:
     */
   def zipWithSymbol(exp: Expression): List[(Symbol, Expression)] =
     given SymbolGenerator with
-      override def prefix: String = tseitinVarPrefix
+      override def prefix: String = converterVarPrefix
     zipWith(exp)(summon[SymbolGenerator].generate)
 
   /** Method to check if an expression is in CNF form and can be converted to CNF form.

--- a/src/main/scala/satify/update/converters/tseitin/Utils.scala
+++ b/src/main/scala/satify/update/converters/tseitin/Utils.scala
@@ -45,18 +45,18 @@ private[converters] object Utils:
       case Or(l, r) => CNFOr(convL(l), convL(r))
       case Symbol(v) => CNFSymbol(v)
       case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
-      case _ => throw new Exception("Expression is not convertible to CNF form")
+      case _ => throw new IllegalArgumentException("Expression is not convertible to CNF form")
 
     def convR(exp: Expression): CNFAnd | CNFOr | Literal = exp match
       case And(l, r) => CNFAnd(convL(l), convR(r))
       case Or(l, r) => CNFOr(convL(l), convL(r))
       case Symbol(v) => CNFSymbol(v)
       case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
-      case _ => throw new Exception("Expression is not convertible to CNF form")
+      case _ => throw new IllegalArgumentException("Expression is not convertible to CNF form")
 
     expression match
       case Symbol(v) => CNFSymbol(v)
       case Not(Symbol(v)) => CNFNot(CNFSymbol(v))
       case And(l, r) => CNFAnd(convL(l), convR(r))
       case Or(l, r) => CNFOr(convL(l), convL(r))
-      case _ => throw new Exception("Expression is not convertible to CNF form")
+      case _ => throw new IllegalArgumentException("Expression is not convertible to CNF form")

--- a/src/main/scala/satify/update/solver/dpll/impl/DpllFinder.scala
+++ b/src/main/scala/satify/update/solver/dpll/impl/DpllFinder.scala
@@ -8,7 +8,7 @@ import satify.model.cnf.CNF.*
 import satify.model.dpll.*
 import satify.model.dpll.DecisionTree.{Branch, Leaf}
 import satify.model.dpll.PartialAssignment.*
-import satify.model.expression.SymbolGeneration.{encodingVarPrefix, tseitinVarPrefix}
+import satify.model.expression.SymbolGeneration.{encodingVarPrefix, converterVarPrefix}
 import satify.model.{Assignment, Result, Solution}
 import satify.update.solver.dpll.DpllDecision.decide
 import satify.update.solver.dpll.cnf.CNFSat.{isSat, isUnsat}
@@ -113,7 +113,7 @@ object DpllFinder:
           optVariables.filter(v =>
             v match
               case OptionalVariable(name, _)
-                  if name.startsWith(encodingVarPrefix) || name.startsWith(tseitinVarPrefix) =>
+                  if name.startsWith(encodingVarPrefix) || name.startsWith(converterVarPrefix) =>
                 false
               case _ => true
           )

--- a/src/test/resources/features/Conversion.feature
+++ b/src/test/resources/features/Conversion.feature
@@ -9,11 +9,11 @@ Feature: Conversion to Conjunctive Normal Form
   Scenario: I want to convert a literal to CNF
     Given the input "a"
     When it is reflected to scala compiler
-    And converted to CNF Form
+    And converted to CNF Form using Tseitin transformation
     Then I should obtain the CNF "a"
 
   Scenario: I want to convert an expression to CNF
-    Given the input "a and b or c"
+    Given the input "a and b"
     When it is reflected to scala compiler
-    And converted to CNF Form
-    Then I should obtain the CNF "TSTN0 and TSTN1 or c or not(TSTN0) and not(TSTN1) or TSTN0 and not(c) or TSTN0 and not(a) or not(b) or TSTN1 and a or not(TSTN1) and b or not(TSTN1)"
+    And converted to CNF Form using Tseitin transformation
+    Then I should obtain the CNF "TSTN0 and not(a) or not(b) or TSTN0 and a or not(TSTN0) and b or not(TSTN0)"

--- a/src/test/resources/features/Conversion.feature
+++ b/src/test/resources/features/Conversion.feature
@@ -1,18 +1,18 @@
 Feature: Conversion to Conjunctive Normal Form
 
-  Scenario: I want to convert a malformed expression to CNF using Tseitin Transformation
+  Scenario: I want to convert a malformed expression to CNF
     Given the input "a ad b"
     When it is reflected to scala compiler
     Then I should obtain an IllegalArgumentException
     And no CNF has to be generated
 
-  Scenario: I want to convert a literal to CNF using Tseitin Transformation
+  Scenario: I want to convert a literal to CNF
     Given the input "a"
     When it is reflected to scala compiler
     And converted to CNF Form
     Then I should obtain the CNF "a"
 
-  Scenario: I want to convert an expression to CNF using Tseitin Transformation
+  Scenario: I want to convert an expression to CNF
     Given the input "a and b or c"
     When it is reflected to scala compiler
     And converted to CNF Form

--- a/src/test/resources/features/Conversion.feature
+++ b/src/test/resources/features/Conversion.feature
@@ -16,4 +16,4 @@ Feature: Conversion to Conjunctive Normal Form
     Given the input "a and b"
     When it is reflected to scala compiler
     And converted to CNF Form using Tseitin transformation
-    Then I should obtain the CNF "TSTN0 and not(a) or not(b) or TSTN0 and a or not(TSTN0) and b or not(TSTN0)"
+    Then I should obtain the CNF "GEN0 and not(a) or not(b) or GEN0 and a or not(GEN0) and b or not(GEN0)"

--- a/src/test/scala/satify/features/ConversionSteps.scala
+++ b/src/test/scala/satify/features/ConversionSteps.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers.*
 import satify.model.cnf.CNF
 import satify.update.converters.{Converter, ConverterType}
 
-object TseitinTransformationSteps extends ScalaDsl with EN:
+object ConversionSteps extends ScalaDsl with EN:
 
   import DSLSteps.*
   var cnf: Option[CNF] = None

--- a/src/test/scala/satify/features/ConversionSteps.scala
+++ b/src/test/scala/satify/features/ConversionSteps.scala
@@ -10,7 +10,7 @@ object ConversionSteps extends ScalaDsl with EN:
   import DSLSteps.*
   var cnf: Option[CNF] = None
 
-  And("converted to CNF Form") {
+  And("converted to CNF Form using Tseitin transformation") {
     try cnf = Some(Converter(ConverterType.Tseitin).convert(expression.get))
     catch case e: IllegalArgumentException => error = IllegalArgumentException(e.getMessage)
   }

--- a/src/test/scala/satify/update/converters/tseitin/ConcatTest.scala
+++ b/src/test/scala/satify/update/converters/tseitin/ConcatTest.scala
@@ -19,7 +19,7 @@ class ConcatTest extends AnyFlatSpec with Matchers:
     val exps: List[CNF] = List(Symbol("a"), Symbol("b"), Symbol("c"))
     val result: CNF = concat(exps)
     val expected: CNF = And(
-      Symbol("TSTN0"),
+      Symbol("GEN0"),
       And(Symbol("a"), And(Symbol("b"), Symbol("c")))
     )
     result shouldBe expected
@@ -30,7 +30,7 @@ class ConcatTest extends AnyFlatSpec with Matchers:
       List(Or(Symbol("a"), Symbol("b")), And(Symbol("c"), Symbol("d")))
     val result: CNF = concat(exps)
     val expected: CNF = And(
-      Symbol("TSTN0"),
+      Symbol("GEN0"),
       And(
         Or(Symbol("a"), Symbol("b")),
         And(Symbol("c"), Symbol("d"))

--- a/src/test/scala/satify/update/converters/tseitin/ReplacingTest.scala
+++ b/src/test/scala/satify/update/converters/tseitin/ReplacingTest.scala
@@ -12,7 +12,7 @@ class ReplacingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = Not(Symbol("b"))
     val result: List[(Symbol, Expression)] = symbolsReplace(exp)
     result should contain only (
-      (Symbol("TSTN0"), Not(Symbol("b")))
+      (Symbol("GEN0"), Not(Symbol("b")))
     )
   }
 
@@ -20,8 +20,8 @@ class ReplacingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = Or(Symbol("a"), Not(Symbol("b")))
     val result: List[(Symbol, Expression)] = symbolsReplace(exp)
     val expected: List[(Symbol, Expression)] = List(
-      (Symbol("TSTN1"), Not(Symbol("b"))),
-      (Symbol("TSTN0"), Or(Symbol("a"), Symbol("TSTN1")))
+      (Symbol("GEN1"), Not(Symbol("b"))),
+      (Symbol("GEN0"), Or(Symbol("a"), Symbol("GEN1")))
     )
     result shouldBe expected
   }
@@ -32,9 +32,9 @@ class ReplacingTest extends AnyFlatSpec with Matchers:
     val list: List[(Symbol, Expression)] = symbolsReplace(exp)
 
     val expectedList: List[(Symbol, Expression)] = List(
-      (Symbol("TSTN2"), Not(Symbol("b"))),
-      (Symbol("TSTN1"), And(Symbol("a"), Symbol("TSTN2"))),
-      (Symbol("TSTN0"), Or(Symbol("TSTN1"), Symbol("c")))
+      (Symbol("GEN2"), Not(Symbol("b"))),
+      (Symbol("GEN1"), And(Symbol("a"), Symbol("GEN2"))),
+      (Symbol("GEN0"), Or(Symbol("GEN1"), Symbol("c")))
     )
     expectedList shouldBe list
   }
@@ -51,11 +51,11 @@ class ReplacingTest extends AnyFlatSpec with Matchers:
 
     val result: List[(Symbol, Expression)] = symbolsReplace(exp)
     val expected: List[(Symbol, Expression)] = List(
-      (Symbol("TSTN2"), And(Symbol("a"), Symbol("b"))),
-      (Symbol("TSTN3"), And(Symbol("c"), Symbol("d"))),
-      (Symbol("TSTN4"), And(Symbol("e"), Symbol("f"))),
-      (Symbol("TSTN1"), Or(Symbol("TSTN2"), Symbol("TSTN3"))),
-      (Symbol("TSTN0"), And(Symbol("TSTN1"), Symbol("TSTN4")))
+      (Symbol("GEN2"), And(Symbol("a"), Symbol("b"))),
+      (Symbol("GEN3"), And(Symbol("c"), Symbol("d"))),
+      (Symbol("GEN4"), And(Symbol("e"), Symbol("f"))),
+      (Symbol("GEN1"), Or(Symbol("GEN2"), Symbol("GEN3"))),
+      (Symbol("GEN0"), And(Symbol("GEN1"), Symbol("GEN4")))
     )
     result shouldBe expected
   }
@@ -69,11 +69,11 @@ class ReplacingTest extends AnyFlatSpec with Matchers:
 
     val result: List[(Symbol, Expression)] = symbolsReplace(exp)
     val expected: List[(Symbol, Expression)] = List(
-      (Symbol("TSTN2"), Or(Symbol("a"), Symbol("b"))),
-      (Symbol("TSTN4"), Not(Symbol("c"))),
-      (Symbol("TSTN1"), And(Symbol("a"), Symbol("TSTN2"))),
-      (Symbol("TSTN3"), And(Symbol("TSTN4"), Symbol("d"))),
-      (Symbol("TSTN0"), Or(Symbol("TSTN1"), Symbol("TSTN3")))
+      (Symbol("GEN2"), Or(Symbol("a"), Symbol("b"))),
+      (Symbol("GEN4"), Not(Symbol("c"))),
+      (Symbol("GEN1"), And(Symbol("a"), Symbol("GEN2"))),
+      (Symbol("GEN3"), And(Symbol("GEN4"), Symbol("d"))),
+      (Symbol("GEN0"), Or(Symbol("GEN1"), Symbol("GEN3")))
     )
     result shouldBe expected
   }

--- a/src/test/scala/satify/update/converters/tseitin/TransformationTest.scala
+++ b/src/test/scala/satify/update/converters/tseitin/TransformationTest.scala
@@ -11,130 +11,130 @@ import satify.update.converters.tseitin.TseitinTransformation.transform
 class TransformationTest extends AnyFlatSpec with Matchers:
 
   "The transformation of ¬(a ∨ b)" should "throw an exception" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Not(Or(Symbol("a"), Symbol("b"))))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Not(Or(Symbol("a"), Symbol("b"))))
     the[IllegalArgumentException] thrownBy transform(exp) should have message "Expression is not a literal"
   }
 
   "The transformation of ((a ∨ c) ∨ (b ∨ d))" should "throw an exception" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Or(Or(Symbol("a"), Symbol("c")), Or(Symbol("b"), Symbol("d"))))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Or(Or(Symbol("a"), Symbol("c")), Or(Symbol("b"), Symbol("d"))))
     the[IllegalArgumentException] thrownBy transform(exp) should have message "Expression is not a literal"
   }
 
   "The transformation of ¬b" should "return a list of CNF clauses relative to the ¬ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Not(Symbol("b")))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Not(Symbol("b")))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
-      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0"))),
-      CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
+      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("GEN0"))),
+      CNFOr(CNFSymbol("b"), CNFSymbol("GEN0"))
     )
     result shouldBe expected
   }
 
   "The transformation of (a ∧ b)" should "return a list of CNF clauses relative to the ∧ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), And(Symbol("a"), Symbol("b")))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), And(Symbol("a"), Symbol("b")))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("b"))),
-        CNFSymbol("TSTN0")
+        CNFSymbol("GEN0")
       ),
-      CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("TSTN0"))),
-      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN0")))
+      CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("GEN0"))),
+      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("GEN0")))
     )
     result shouldBe expected
   }
 
   "The transformation of (¬a ∧ b)" should "return a list of CNF clauses relative to the ∧ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), And(Not(Symbol("a")), Symbol("b")))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), And(Not(Symbol("a")), Symbol("b")))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("b"))),
-        CNFSymbol("TSTN0")
+        CNFSymbol("GEN0")
       ),
-      CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN0"))),
-      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN0")))
+      CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("GEN0"))),
+      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("GEN0")))
     )
     result shouldBe expected
   }
 
   "The transformation of (a ∧ ¬b)" should "return a list of CNF clauses relative to the ∧ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), And(Symbol("a"), Not(Symbol("b"))))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), And(Symbol("a"), Not(Symbol("b"))))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("b")),
-        CNFSymbol("TSTN0")
+        CNFSymbol("GEN0")
       ),
-      CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("TSTN0"))),
-      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0")))
+      CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("GEN0"))),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("GEN0")))
     )
     result shouldBe expected
   }
 
   "The transformation of (¬a ∧ ¬b)" should "return a list of CNF clauses relative to the ∧ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), And(Not(Symbol("a")), Not(Symbol("b"))))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), And(Not(Symbol("a")), Not(Symbol("b"))))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
-      CNFOr(CNFOr(CNFSymbol("a"), CNFSymbol("b")), CNFSymbol("TSTN0")),
-      CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN0"))),
-      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0")))
+      CNFOr(CNFOr(CNFSymbol("a"), CNFSymbol("b")), CNFSymbol("GEN0")),
+      CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("GEN0"))),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("GEN0")))
     )
     result shouldBe expected
   }
 
   "The transformation of (a ∨ b)" should "return a list of CNF clauses relative to the ∨ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Or(Symbol("a"), Symbol("b")))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Or(Symbol("a"), Symbol("b")))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFSymbol("a"), CNFSymbol("b")),
-        CNFNot(CNFSymbol("TSTN0"))
+        CNFNot(CNFSymbol("GEN0"))
       ),
-      CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("TSTN0")),
-      CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("TSTN0"))
+      CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("GEN0")),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("GEN0"))
     )
     result shouldBe expected
   }
 
   "The transformation of (¬a ∨ b)" should "return a list of CNF clauses relative to the ∨ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Or(Not(Symbol("a")), Symbol("b")))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Or(Not(Symbol("a")), Symbol("b")))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("b")),
-        CNFNot(CNFSymbol("TSTN0"))
+        CNFNot(CNFSymbol("GEN0"))
       ),
-      CNFOr(CNFSymbol("a"), CNFSymbol("TSTN0")),
-      CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("TSTN0"))
+      CNFOr(CNFSymbol("a"), CNFSymbol("GEN0")),
+      CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("GEN0"))
     )
     result shouldBe expected
   }
 
   "The transformation of (a ∨ ¬b)" should "return a list of CNF clauses relative to the ∨ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Or(Symbol("a"), Not(Symbol("b"))))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Or(Symbol("a"), Not(Symbol("b"))))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("b"))),
-        CNFNot(CNFSymbol("TSTN0"))
+        CNFNot(CNFSymbol("GEN0"))
       ),
-      CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("TSTN0")),
-      CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
+      CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("GEN0")),
+      CNFOr(CNFSymbol("b"), CNFSymbol("GEN0"))
     )
     result shouldBe expected
   }
 
   "The transformation of (¬a ∨ ¬b)" should "return a list of CNF clauses relative to the ∨ operator" in {
-    val exp: (Symbol, Expression) = (Symbol("TSTN0"), Or(Not(Symbol("a")), Not(Symbol("b"))))
+    val exp: (Symbol, Expression) = (Symbol("GEN0"), Or(Not(Symbol("a")), Not(Symbol("b"))))
     val result: List[CNF] = transform(exp)
     val expected: List[CNF] = List(
       CNFOr(
         CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("b"))),
-        CNFNot(CNFSymbol("TSTN0"))
+        CNFNot(CNFSymbol("GEN0"))
       ),
-      CNFOr(CNFSymbol("a"), CNFSymbol("TSTN0")),
-      CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
+      CNFOr(CNFSymbol("a"), CNFSymbol("GEN0")),
+      CNFOr(CNFSymbol("b"), CNFSymbol("GEN0"))
     )
     result shouldBe expected
   }

--- a/src/test/scala/satify/update/converters/tseitin/TseitinTest.scala
+++ b/src/test/scala/satify/update/converters/tseitin/TseitinTest.scala
@@ -20,10 +20,10 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Not(Symbol("b"))
     val result = tseitin(exp)
     val expected: CNF = CNFAnd(
-      CNFSymbol("TSTN0"),
+      CNFSymbol("GEN0"),
       CNFAnd(
-        CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN0"))),
-        CNFOr(CNFSymbol("b"), CNFSymbol("TSTN0"))
+        CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("GEN0"))),
+        CNFOr(CNFSymbol("b"), CNFSymbol("GEN0"))
       )
     )
     result shouldBe expected
@@ -33,15 +33,15 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Or(Symbol("a"), Symbol("b"))
     val result = tseitin(exp)
     val expected: CNF = CNFAnd(
-      CNFSymbol("TSTN0"),
+      CNFSymbol("GEN0"),
       CNFAnd(
         CNFOr(
           CNFOr(CNFSymbol("a"), CNFSymbol("b")),
-          CNFNot(CNFSymbol("TSTN0"))
+          CNFNot(CNFSymbol("GEN0"))
         ),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("TSTN0")),
-          CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("TSTN0"))
+          CNFOr(CNFNot(CNFSymbol("a")), CNFSymbol("GEN0")),
+          CNFOr(CNFNot(CNFSymbol("b")), CNFSymbol("GEN0"))
         )
       )
     )
@@ -52,28 +52,28 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Or(And(Symbol("a"), Not(Symbol("b"))), Symbol("c"))
     val result = tseitin(exp)
     val expected = CNFAnd(
-      CNFSymbol("TSTN0"),
+      CNFSymbol("GEN0"),
       CNFAnd(
         CNFOr(
-          CNFOr(CNFSymbol("TSTN1"), CNFSymbol("c")),
-          CNFNot(CNFSymbol("TSTN0"))
+          CNFOr(CNFSymbol("GEN1"), CNFSymbol("c")),
+          CNFNot(CNFSymbol("GEN0"))
         ),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol("TSTN1")), CNFSymbol("TSTN0")),
+          CNFOr(CNFNot(CNFSymbol("GEN1")), CNFSymbol("GEN0")),
           CNFAnd(
-            CNFOr(CNFNot(CNFSymbol("c")), CNFSymbol("TSTN0")),
+            CNFOr(CNFNot(CNFSymbol("c")), CNFSymbol("GEN0")),
             CNFAnd(
               CNFOr(
-                CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN2"))),
-                CNFSymbol("TSTN1")
+                CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("GEN2"))),
+                CNFSymbol("GEN1")
               ),
               CNFAnd(
-                CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("TSTN1"))),
+                CNFOr(CNFSymbol("a"), CNFNot(CNFSymbol("GEN1"))),
                 CNFAnd(
-                  CNFOr(CNFSymbol("TSTN2"), CNFNot(CNFSymbol("TSTN1"))),
+                  CNFOr(CNFSymbol("GEN2"), CNFNot(CNFSymbol("GEN1"))),
                   CNFAnd(
-                    CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("TSTN2"))),
-                    CNFOr(CNFSymbol("b"), CNFSymbol("TSTN2"))
+                    CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("GEN2"))),
+                    CNFOr(CNFSymbol("b"), CNFSymbol("GEN2"))
                   )
                 )
               )
@@ -89,28 +89,28 @@ class TseitinTest extends AnyFlatSpec with Matchers:
     val exp = Or(Or(Not(Symbol("a")), And(Symbol("b"), Symbol("c"))), Symbol("d"))
     val result = tseitin(exp)
     val expected: CNF = CNFAnd(
-      CNFSymbol("TSTN0"),
+      CNFSymbol("GEN0"),
       CNFAnd(
-        CNFOr(CNFOr(CNFSymbol("TSTN1"), CNFSymbol("d")), CNFNot(CNFSymbol("TSTN0"))),
+        CNFOr(CNFOr(CNFSymbol("GEN1"), CNFSymbol("d")), CNFNot(CNFSymbol("GEN0"))),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol("TSTN1")), CNFSymbol("TSTN0")),
+          CNFOr(CNFNot(CNFSymbol("GEN1")), CNFSymbol("GEN0")),
           CNFAnd(
-            CNFOr(CNFNot(CNFSymbol("d")), CNFSymbol("TSTN0")),
+            CNFOr(CNFNot(CNFSymbol("d")), CNFSymbol("GEN0")),
             CNFAnd(
-              CNFOr(CNFOr(CNFSymbol("TSTN2"), CNFSymbol("TSTN3")), CNFNot(CNFSymbol("TSTN1"))),
+              CNFOr(CNFOr(CNFSymbol("GEN2"), CNFSymbol("GEN3")), CNFNot(CNFSymbol("GEN1"))),
               CNFAnd(
-                CNFOr(CNFNot(CNFSymbol("TSTN2")), CNFSymbol("TSTN1")),
+                CNFOr(CNFNot(CNFSymbol("GEN2")), CNFSymbol("GEN1")),
                 CNFAnd(
-                  CNFOr(CNFNot(CNFSymbol("TSTN3")), CNFSymbol("TSTN1")),
+                  CNFOr(CNFNot(CNFSymbol("GEN3")), CNFSymbol("GEN1")),
                   CNFAnd(
-                    CNFOr(CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("c"))), CNFSymbol("TSTN3")),
+                    CNFOr(CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("c"))), CNFSymbol("GEN3")),
                     CNFAnd(
-                      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN3"))),
+                      CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("GEN3"))),
                       CNFAnd(
-                        CNFOr(CNFSymbol("c"), CNFNot(CNFSymbol("TSTN3"))),
+                        CNFOr(CNFSymbol("c"), CNFNot(CNFSymbol("GEN3"))),
                         CNFAnd(
-                          CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN2"))),
-                          CNFOr(CNFSymbol("a"), CNFSymbol("TSTN2"))
+                          CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("GEN2"))),
+                          CNFOr(CNFSymbol("a"), CNFSymbol("GEN2"))
                         )
                       )
                     )

--- a/src/test/scala/satify/update/converters/tseitin/utils/CNFConverter.scala
+++ b/src/test/scala/satify/update/converters/tseitin/utils/CNFConverter.scala
@@ -39,34 +39,34 @@ class CNFConverter extends AnyFlatSpec with Matchers:
   "The exp" should "be converted to CNF" in {
     val exp = And(
       Or(
-        Or(Symbol("TSTN1"), Symbol("d")),
-        Not(Symbol("TSTN0"))
+        Or(Symbol("GEN1"), Symbol("d")),
+        Not(Symbol("GEN0"))
       ),
       And(
-        Or(Not(Symbol("TSTN1")), Symbol("TSTN0")),
+        Or(Not(Symbol("GEN1")), Symbol("GEN0")),
         And(
-          Or(Not(Symbol("d")), Symbol("TSTN0")),
+          Or(Not(Symbol("d")), Symbol("GEN0")),
           And(
             Or(
-              Or(Symbol("TSTN2"), Symbol("TSTN3")),
-              Not(Symbol("TSTN1"))
+              Or(Symbol("GEN2"), Symbol("GEN3")),
+              Not(Symbol("GEN1"))
             ),
             And(
-              Or(Not(Symbol("TSTN2")), Symbol("TSTN1")),
+              Or(Not(Symbol("GEN2")), Symbol("GEN1")),
               And(
-                Or(Not(Symbol("TSTN3")), Symbol("TSTN1")),
+                Or(Not(Symbol("GEN3")), Symbol("GEN1")),
                 And(
-                  Or(Not(Symbol("a")), Not(Symbol("TSTN2"))),
+                  Or(Not(Symbol("a")), Not(Symbol("GEN2"))),
                   And(
-                    Or(Symbol("a"), Symbol("TSTN2")),
+                    Or(Symbol("a"), Symbol("GEN2")),
                     And(
                       Or(
                         Or(Not(Symbol("b")), Not(Symbol("c"))),
-                        Symbol("TSTN3")
+                        Symbol("GEN3")
                       ),
                       And(
-                        Or(Symbol("b"), Not(Symbol("TSTN3"))),
-                        Or(Symbol("c"), Not(Symbol("TSTN3")))
+                        Or(Symbol("b"), Not(Symbol("GEN3"))),
+                        Or(Symbol("c"), Not(Symbol("GEN3")))
                       )
                     )
                   )
@@ -81,34 +81,34 @@ class CNFConverter extends AnyFlatSpec with Matchers:
     val result: CNF = convertToCNF(exp)
     val expected = CNFAnd(
       CNFOr(
-        CNFOr(CNFSymbol("TSTN1"), CNFSymbol("d")),
-        CNFNot(CNFSymbol("TSTN0"))
+        CNFOr(CNFSymbol("GEN1"), CNFSymbol("d")),
+        CNFNot(CNFSymbol("GEN0"))
       ),
       CNFAnd(
-        CNFOr(CNFNot(CNFSymbol("TSTN1")), CNFSymbol("TSTN0")),
+        CNFOr(CNFNot(CNFSymbol("GEN1")), CNFSymbol("GEN0")),
         CNFAnd(
-          CNFOr(CNFNot(CNFSymbol("d")), CNFSymbol("TSTN0")),
+          CNFOr(CNFNot(CNFSymbol("d")), CNFSymbol("GEN0")),
           CNFAnd(
             CNFOr(
-              CNFOr(CNFSymbol("TSTN2"), CNFSymbol("TSTN3")),
-              CNFNot(CNFSymbol("TSTN1"))
+              CNFOr(CNFSymbol("GEN2"), CNFSymbol("GEN3")),
+              CNFNot(CNFSymbol("GEN1"))
             ),
             CNFAnd(
-              CNFOr(CNFNot(CNFSymbol("TSTN2")), CNFSymbol("TSTN1")),
+              CNFOr(CNFNot(CNFSymbol("GEN2")), CNFSymbol("GEN1")),
               CNFAnd(
-                CNFOr(CNFNot(CNFSymbol("TSTN3")), CNFSymbol("TSTN1")),
+                CNFOr(CNFNot(CNFSymbol("GEN3")), CNFSymbol("GEN1")),
                 CNFAnd(
-                  CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("TSTN2"))),
+                  CNFOr(CNFNot(CNFSymbol("a")), CNFNot(CNFSymbol("GEN2"))),
                   CNFAnd(
-                    CNFOr(CNFSymbol("a"), CNFSymbol("TSTN2")),
+                    CNFOr(CNFSymbol("a"), CNFSymbol("GEN2")),
                     CNFAnd(
                       CNFOr(
                         CNFOr(CNFNot(CNFSymbol("b")), CNFNot(CNFSymbol("c"))),
-                        CNFSymbol("TSTN3")
+                        CNFSymbol("GEN3")
                       ),
                       CNFAnd(
-                        CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("TSTN3"))),
-                        CNFOr(CNFSymbol("c"), CNFNot(CNFSymbol("TSTN3")))
+                        CNFOr(CNFSymbol("b"), CNFNot(CNFSymbol("GEN3"))),
+                        CNFOr(CNFSymbol("c"), CNFNot(CNFSymbol("GEN3")))
                       )
                     )
                   )

--- a/src/test/scala/satify/update/converters/tseitin/utils/CNFValidator.scala
+++ b/src/test/scala/satify/update/converters/tseitin/utils/CNFValidator.scala
@@ -37,34 +37,34 @@ class CNFValidator extends AnyFlatSpec with Matchers:
   "The exp ((a ∧ ¬b) ∨ c)" should "be validated as CNF" in {
     val exp = And(
       Or(
-        Or(Symbol("TSTN1"), Symbol("d")),
-        Not(Symbol("TSTN0"))
+        Or(Symbol("GEN1"), Symbol("d")),
+        Not(Symbol("GEN0"))
       ),
       And(
-        Or(Not(Symbol("TSTN1")), Symbol("TSTN0")),
+        Or(Not(Symbol("GEN1")), Symbol("GEN0")),
         And(
-          Or(Not(Symbol("d")), Symbol("TSTN0")),
+          Or(Not(Symbol("d")), Symbol("GEN0")),
           And(
             Or(
-              Or(Symbol("TSTN2"), Symbol("TSTN3")),
-              Not(Symbol("TSTN1"))
+              Or(Symbol("GEN2"), Symbol("GEN3")),
+              Not(Symbol("GEN1"))
             ),
             And(
-              Or(Not(Symbol("TSTN2")), Symbol("TSTN1")),
+              Or(Not(Symbol("GEN2")), Symbol("GEN1")),
               And(
-                Or(Not(Symbol("TSTN3")), Symbol("TSTN1")),
+                Or(Not(Symbol("GEN3")), Symbol("GEN1")),
                 And(
-                  Or(Not(Symbol("a")), Not(Symbol("TSTN2"))),
+                  Or(Not(Symbol("a")), Not(Symbol("GEN2"))),
                   And(
-                    Or(Symbol("a"), Symbol("TSTN2")),
+                    Or(Symbol("a"), Symbol("GEN2")),
                     And(
                       Or(
                         Or(Not(Symbol("b")), Not(Symbol("c"))),
-                        Symbol("TSTN3")
+                        Symbol("GEN3")
                       ),
                       And(
-                        Or(Symbol("b"), Not(Symbol("TSTN3"))),
-                        Or(Symbol("c"), Not(Symbol("TSTN3")))
+                        Or(Symbol("b"), Not(Symbol("GEN3"))),
+                        Or(Symbol("c"), Not(Symbol("GEN3")))
                       )
                     )
                   )

--- a/src/test/scala/satify/update/converters/tseitin/utils/ZippingTest.scala
+++ b/src/test/scala/satify/update/converters/tseitin/utils/ZippingTest.scala
@@ -13,10 +13,10 @@ class ZippingTest extends AnyFlatSpec with Matchers:
       Or(And(Symbol("a"), Not(Symbol("b"))), Symbol("c"))
     val list = zipWithSymbol(exp)
     list should contain only (
-      (Symbol("TSTN2"), Not(Symbol("b"))),
-      (Symbol("TSTN1"), And(Symbol("a"), Not(Symbol("b")))),
+      (Symbol("GEN2"), Not(Symbol("b"))),
+      (Symbol("GEN1"), And(Symbol("a"), Not(Symbol("b")))),
       (
-        Symbol("TSTN0"),
+        Symbol("GEN0"),
         Or(And(Symbol("a"), Not(Symbol("b"))), Symbol("c"))
       )
     )
@@ -25,13 +25,13 @@ class ZippingTest extends AnyFlatSpec with Matchers:
   "In a the subexp a" should "be decomposed correctly" in {
     val exp: Expression = Symbol("a")
     val list = zipWithSymbol(exp)
-    list should contain only ((Symbol("TSTN0"), Symbol("a")))
+    list should contain only ((Symbol("GEN0"), Symbol("a")))
   }
 
   "In ¬a the subexp ¬a" should "be decomposed correctly" in {
     val exp: Expression = Not(Symbol("a"))
     val list = zipWithSymbol(exp)
-    list should contain only ((Symbol("TSTN0"), Not(Symbol("a"))))
+    list should contain only ((Symbol("GEN0"), Not(Symbol("a"))))
   }
 
   "In (c ∧ (a ∧ ¬b)) the subexp ¬b, (a ∧ ¬b) and (c ∧ (a ∧ ¬b))" should "be decomposed correctly" in {
@@ -40,11 +40,11 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val list = zipWithSymbol(exp)
     list should contain only (
       (
-        Symbol("TSTN0"),
+        Symbol("GEN0"),
         And(Symbol("c"), And(Symbol("a"), Not(Symbol("b"))))
       ),
-      (Symbol("TSTN1"), And(Symbol("a"), Not(Symbol("b")))),
-      (Symbol("TSTN2"), Not(Symbol("b")))
+      (Symbol("GEN1"), And(Symbol("a"), Not(Symbol("b")))),
+      (Symbol("GEN2"), Not(Symbol("b")))
     )
   }
 
@@ -52,7 +52,7 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = And(Symbol("c"), Symbol("a"))
     val list = zipWithSymbol(exp)
     list should contain only (
-      (Symbol("TSTN0"), And(Symbol("c"), Symbol("a")))
+      (Symbol("GEN0"), And(Symbol("c"), Symbol("a")))
     )
   }
 
@@ -60,7 +60,7 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = Symbol("a")
     val result = zipWithSymbol(exp)
     val expected = List(
-      (Symbol("TSTN0"), Symbol("a"))
+      (Symbol("GEN0"), Symbol("a"))
     )
     result shouldBe expected
   }
@@ -69,7 +69,7 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = Not(Symbol("a"))
     val result = zipWithSymbol(exp)
     val expected = List(
-      (Symbol("TSTN0"), Not(Symbol("a")))
+      (Symbol("GEN0"), Not(Symbol("a")))
     )
     result shouldBe expected
   }
@@ -80,11 +80,11 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val result = zipWithSymbol(exp)
     val expected = List(
       (
-        Symbol("TSTN0"),
+        Symbol("GEN0"),
         And(Symbol("c"), And(Symbol("a"), Not(Symbol("b"))))
       ),
-      (Symbol("TSTN1"), And(Symbol("a"), Not(Symbol("b")))),
-      (Symbol("TSTN2"), Not(Symbol("b")))
+      (Symbol("GEN1"), And(Symbol("a"), Not(Symbol("b")))),
+      (Symbol("GEN2"), Not(Symbol("b")))
     )
     result shouldBe expected
   }
@@ -93,7 +93,7 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = And(Symbol("c"), Symbol("a"))
     val result = zipWithSymbol(exp)
     val expected = List(
-      (Symbol("TSTN0"), And(Symbol("c"), Symbol("a")))
+      (Symbol("GEN0"), And(Symbol("c"), Symbol("a")))
     )
     result shouldBe expected
   }
@@ -106,15 +106,15 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val result = zipWithSymbol(exp)
     val expected = List(
       (
-        Symbol("TSTN0"),
+        Symbol("GEN0"),
         Or(
           Not(And(Symbol("p"), Symbol("q"))),
           Or(Symbol("r"), Symbol("s"))
         )
       ),
-      (Symbol("TSTN1"), Not(And(Symbol("p"), Symbol("q")))),
-      (Symbol("TSTN2"), And(Symbol("p"), Symbol("q"))),
-      (Symbol("TSTN3"), Or(Symbol("r"), Symbol("s")))
+      (Symbol("GEN1"), Not(And(Symbol("p"), Symbol("q")))),
+      (Symbol("GEN2"), And(Symbol("p"), Symbol("q"))),
+      (Symbol("GEN3"), Or(Symbol("r"), Symbol("s")))
     )
     result shouldBe expected
   }
@@ -123,8 +123,8 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = Not(And(Symbol("a"), Symbol("b")))
     val result = zipWithSymbol(exp)
     val expected = List(
-      (Symbol("TSTN0"), Not(And(Symbol("a"), Symbol("b")))),
-      (Symbol("TSTN1"), And(Symbol("a"), Symbol("b")))
+      (Symbol("GEN0"), Not(And(Symbol("a"), Symbol("b")))),
+      (Symbol("GEN1"), And(Symbol("a"), Symbol("b")))
     )
     result shouldBe expected
   }
@@ -137,15 +137,15 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val result = zipWithSymbol(exp)
     val expected = List(
       (
-        Symbol("TSTN0"),
+        Symbol("GEN0"),
         Or(
           Not(And(Symbol("p"), Symbol("q"))),
           Or(Symbol("r"), Symbol("s"))
         )
       ),
-      (Symbol("TSTN1"), Not(And(Symbol("p"), Symbol("q")))),
-      (Symbol("TSTN2"), And(Symbol("p"), Symbol("q"))),
-      (Symbol("TSTN3"), Or(Symbol("r"), Symbol("s")))
+      (Symbol("GEN1"), Not(And(Symbol("p"), Symbol("q")))),
+      (Symbol("GEN2"), And(Symbol("p"), Symbol("q"))),
+      (Symbol("GEN3"), Or(Symbol("r"), Symbol("s")))
     )
     result shouldBe expected
   }
@@ -154,8 +154,8 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val exp: Expression = Not(And(Symbol("a"), Symbol("b")))
     val result = zipWithSymbol(exp)
     val expected = List(
-      (Symbol("TSTN0"), Not(And(Symbol("a"), Symbol("b")))),
-      (Symbol("TSTN1"), And(Symbol("a"), Symbol("b")))
+      (Symbol("GEN0"), Not(And(Symbol("a"), Symbol("b")))),
+      (Symbol("GEN1"), And(Symbol("a"), Symbol("b")))
     )
     result shouldBe expected
   }
@@ -171,7 +171,7 @@ class ZippingTest extends AnyFlatSpec with Matchers:
     val result = zipWithSymbol(exp)
     val expected = List(
       (
-        Symbol("TSTN0"),
+        Symbol("GEN0"),
         And(
           And(
             Or(Symbol("a"), And(Symbol("b"), Symbol("c"))),
@@ -181,18 +181,18 @@ class ZippingTest extends AnyFlatSpec with Matchers:
         )
       ),
       (
-        Symbol("TSTN1"),
+        Symbol("GEN1"),
         And(
           Or(Symbol("a"), And(Symbol("b"), Symbol("c"))),
           Symbol("d")
         )
       ),
       (
-        Symbol("TSTN2"),
+        Symbol("GEN2"),
         Or(Symbol("a"), And(Symbol("b"), Symbol("c")))
       ),
-      (Symbol("TSTN3"), And(Symbol("b"), Symbol("c"))),
-      (Symbol("TSTN4"), Or(Symbol("s"), Symbol("t")))
+      (Symbol("GEN3"), And(Symbol("b"), Symbol("c"))),
+      (Symbol("GEN4"), Or(Symbol("s"), Symbol("t")))
     )
     result shouldBe expected
   }


### PR DESCRIPTION
- Fix Exception in convertToCNF method but maybe it is better to remove it 
- Fix BDD tests for converters 
- Fix name for generated variables: TSTN to GEN because every converter generate variables and following this approach there will be no need to exclude other variables names while processing the input. 

